### PR TITLE
Fixes reference to types declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "devseed UI Kit Collecticons for Chakra",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
-  "types": "./lib/index.d.ts",
+  "types": "./dist/index.d.ts",
   "sideEffects": false,
   "scripts": {
     "serve": "parcel showcase/index.html --dist-dir dist_site -p 9000",


### PR DESCRIPTION
I ran into a TypeScript issue when using Collecticons for Chakra:

```
TS7016: Could not find a declaration file for module '@devseed-ui/collecticons-chakra'.
```

It looks like the `types` reference in package.json needs to be pointed to `index.d.ts`, which exists in `dist` not `lib`